### PR TITLE
Resolve relative paths before passing to handle.exe

### DIFF
--- a/hooks/purge.ps1
+++ b/hooks/purge.ps1
@@ -13,8 +13,9 @@ param(
 
 pslist -t -accepteula -nobanner
 
-"Finding handles in $Dir"
-$OUT=$(handle64 -accepteula -nobanner $Dir)
+$absDir = Resolve-Path $Dir
+"Finding handles in $absDir"
+$OUT=$(handle64 -accepteula -nobanner $absDir)
 
 $processMap = @{}
 ForEach ($line in $OUT -split "`r`n")


### PR DESCRIPTION
Handle.exe does not support relative paths like this, since it tries to match the filepath directly to file handle objects