### PR TITLE
Skip hook if directory to check handles for doesn't exist

### DIFF
--- a/hooks/purge.ps1
+++ b/hooks/purge.ps1
@@ -15,7 +15,7 @@ pslist -t -accepteula -nobanner
 
 if (Test-Path -Path $Dir) {
 	$absDir = Resolve-Path $Dir -ErrorAction Stop
-} else {{
+} else {
 	Write-Output "Skipping: Directory $($Dir) does not exist, no file-handles can exist."
 	exit 0
 }

--- a/hooks/purge.ps1
+++ b/hooks/purge.ps1
@@ -13,7 +13,12 @@ param(
 
 pslist -t -accepteula -nobanner
 
-$absDir = Resolve-Path $Dir
+if (Test-Path -Path $Dir) {
+	$absDir = Resolve-Path $Dir -ErrorAction Stop
+} else {
+	"Directory $Dir does not exist, skipping"
+	exit 0
+}
 "Finding handles in $absDir"
 $OUT=$(handle64 -accepteula -nobanner $absDir)
 

--- a/hooks/purge.ps1
+++ b/hooks/purge.ps1
@@ -15,11 +15,11 @@ pslist -t -accepteula -nobanner
 
 if (Test-Path -Path $Dir) {
 	$absDir = Resolve-Path $Dir -ErrorAction Stop
-} else {
-	"Directory $Dir does not exist, skipping"
+} else {{
+	Write-Output "Skipping: Directory $($Dir) does not exist, no file-handles can exist."
 	exit 0
 }
-"Finding handles in $absDir"
+Write-Output "Finding handles in $absDir"
 $OUT=$(handle64 -accepteula -nobanner $absDir)
 
 $processMap = @{}
@@ -36,18 +36,18 @@ ForEach ($line in $OUT -split "`r`n")
 
 if ($processMap.Count -eq 0)
 {
-    "No handles found."
+    Write-Output "No handles found."
 }
 else
 {
 	$processMap | Format-Table
 
-	"Whitelisted: $Whitelist"
+	Write-Output "Whitelisted: $Whitelist"
 	foreach($ppid in $processMap.keys)
 	{
 		$imageName = $processMap.$ppid
 		if (! $Whitelist.Contains($imageName)){
-			"Killing $ppid"
+			Write-Output "Killing $ppid"
 			taskkill /f /t /pid $ppid
 		}
 	}


### PR DESCRIPTION
This can be the case for e.g. if it's the first build on that machine, so the build directory hasn't even been created yet.

In this case, it's impossible for there to be any open file handles in the directory so we can safely skip this plugin.