### PR TITLE
ENG-3396 Cleanup any stuck processes after command has run

### DIFF
--- a/hooks/post-command.bat
+++ b/hooks/post-command.bat
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Bypass -NoProfile -NonInteractive %~dp0/purge.ps1 -Dir "%BUILDKITE_BUILD_CHECKOUT_PATH%" %BUILDKITE_PLUGIN_TASKKILL_WHITELIST%


### PR DESCRIPTION
Speculatively running purge as a `post-command` in order to decrease the chance of a bk agent not being able to terminate stuck jobs. This hook makes it possible to cleanup a workspace in the cases where a job was canceled/stopped. 

https://buildkite.com/docs/agent/v3/hooks#types-of-hooks